### PR TITLE
fix race condition between drop and dragend

### DIFF
--- a/sortable-list.html
+++ b/sortable-list.html
@@ -97,6 +97,7 @@ https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills
        */
       dragstart: function(evt) {
         var sortableList = this.parentNode;
+        this.originalParentNode = sortableList;
         var index = String(sortableList.getIndex(this));
         evt.dataTransfer.effectAllowed = "move";
         evt.dataTransfer.setData("text", index+','+sortableList.group);
@@ -208,7 +209,7 @@ https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills
       **/
       dragend: function(evt){
         evt.preventDefault();
-        let sortableList = this.parentNode;
+        let sortableList = this.originalParentNode;
         // remove dragged state styling class
         sortableList.querySelector('.dragged').classList.remove('dragged');
         if(sortableList.isEdge || sortableList.isIE) {


### PR DESCRIPTION
If drop event splices the items out of the list, parentNode becomes #document-fragment. As a result we cannot cleanup the ghostEl we have created